### PR TITLE
Ignoring results from threads for now to avoid crashing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -199,9 +199,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             Ok(())
         });
 
-    camera_thread.join().unwrap()?;
-    lidar_thread.join().unwrap().unwrap();
-    gps_thread.join().unwrap().unwrap();
+    let _ = camera_thread.join();
+    let _ = lidar_thread.join();
+    let _ = gps_thread.join();
     Ok(())
 }
 


### PR DESCRIPTION
- As we may not be using all sensors at the same time, this removes the
  unwraps from joins so that if `sensorview` isn't listening for a
  particular sensor, `rc_car` will continue sending data for the sensors
  that are being subscribed to. This should really be reworked, but shall
  suffice for this iteration.